### PR TITLE
Added function "bool is<X>()"

### DIFF
--- a/variant.h
+++ b/variant.h
@@ -151,6 +151,14 @@ public:
 			);
 		}
 	}
+	template<typename X>
+	bool is() const {
+		static_assert(
+			impl::position<X, Types...>::pos != -1,
+			"Type not in variant."
+		);
+		return tag == impl::position<X, Types...>::pos;
+	}
 	template<typename visitor>
 	typename visitor::result_type visit(visitor& v) {
 		return impl::storage_ops<0, Types...>::apply(tag, storage, v);


### PR DESCRIPTION
I think this is more convenient to use than using which() for determining contents, at least in some cases.

For example, when I had to add and remove some types from a variant, I had to manually find all the which() calls and change the tag values I was comparing against.